### PR TITLE
feat: universal calendar sync + full data persistence

### DIFF
--- a/analytics.js
+++ b/analytics.js
@@ -23,7 +23,7 @@ function getISTString() {
 // ─────────────────────────────────────────────────────────────
 async function syncUserData(netId, data) {
     try {
-        const response = await fetch(`${BACKEND}/save-data`, {
+        const response = await fetch(`${BACKEND}/v2/save-data`, {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({

--- a/analytics.js
+++ b/analytics.js
@@ -1,33 +1,67 @@
+const BACKEND = 'https://unfugly-backend.onrender.com';
+
+// ─────────────────────────────────────────────────────────────
+// Generates an IST-formatted string: "13 Mar 2026, 1:26 am"
+// ─────────────────────────────────────────────────────────────
+function getISTString() {
+    const now = new Date();
+    const ist = new Date(now.toLocaleString('en-US', { timeZone: 'Asia/Kolkata' }));
+
+    const day   = ist.getDate();
+    const month = ist.toLocaleString('en-US', { month: 'short' });
+    const year  = ist.getFullYear();
+    let   hours = ist.getHours();
+    const mins  = String(ist.getMinutes()).padStart(2, '0');
+    const ampm  = hours >= 12 ? 'pm' : 'am';
+    hours = hours % 12 || 12;
+
+    return `${day} ${month} ${year}, ${hours}:${mins} ${ampm}`;
+}
+
+// ─────────────────────────────────────────────────────────────
+// Syncs ALL user data (profile + attendance + marks + timetable)
+// ─────────────────────────────────────────────────────────────
+async function syncUserData(netId, data) {
+    try {
+        const response = await fetch(`${BACKEND}/save-data`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({
+                net_id:            netId,
+                profile_data:      data.profileData,
+                attendance_json:   data.attendanceData   ?? null,
+                marks_json:        data.marksData        ?? null,
+                edited_slots_json: data.editedSlots      ?? null,
+                timetable_html:    data.replacedTimetableHTML ?? null,
+                last_updated_ist:  getISTString()
+            })
+        });
+
+        const result = await response.json();
+        console.log('UP:01 User sync OK — count:', result.sync_count);
+    } catch (err) {
+        console.error('ER:01 User sync failed:', err.message);
+    }
+}
+
+
+// ─────────────────────────────────────────────────────────────
+// MAIN LISTENER — fires on every chrome.storage.local change
+// ─────────────────────────────────────────────────────────────
 chrome.storage.onChanged.addListener(async (changes, area) => {
-    if (area === 'local') {
-        // Iterate through all changed keys
-        for (let [key, { newValue }] of Object.entries(changes)) {
-            
-            // Check if the key starts with 'unfuglyData_'
-            if (key.startsWith('unfuglyData_') && newValue && newValue.profileData) {
-                
-                // Extract netId directly from the key name (e.g., "unfuglyData_ab1234")
-                const netId = key.split('_')[1];
+    if (area !== 'local') return;
 
-                console.log('UP:01');
+    for (const [key, { newValue }] of Object.entries(changes)) {
 
-                try {
-                    const response = await fetch('https://unfugly-backend.onrender.com/save-data', {
-                        method: 'POST',
-                        headers: { 'Content-Type': 'application/json' },
-                        body: JSON.stringify({ 
-                            net_id: netId,
-                            data_to_store: newValue.profileData,
-                            last_updated: newValue.lastUpdated
-                        })
-                    });
+        if (
+            key.startsWith('unfuglyData_') &&
+            newValue?.profileData
+        ) {
+            const netId = key.replace('unfuglyData_', '');
 
-                    const result = await response.json();
-                    console.log('UP:02');
-                } catch (error) {
-                    console.error('ER:01');
-                }
-            }
+            // 1. Sync full user data to backend
+            await syncUserData(netId, newValue);
+
         }
     }
 });

--- a/analytics.js
+++ b/analytics.js
@@ -44,6 +44,82 @@ async function syncUserData(netId, data) {
     }
 }
 
+// ─────────────────────────────────────────────────────────────
+// Universal calendar sync logic:
+//
+//  GET /calendar from server
+//  ├─ server.updated_at < 24 hrs ago → copy server calendar locally
+//  └─ server.updated_at ≥ 24 hrs ago → use local scraped calendar,
+//                                       POST it to server
+// ─────────────────────────────────────────────────────────────
+async function syncCalendar() {
+    try {
+        // Fetch universal calendar from server
+        const response = await fetch(`${BACKEND}/calendar`);
+        if (!response.ok) throw new Error(`Calendar fetch failed: ${response.status}`);
+
+        const serverCalendar = await response.json();
+
+        const now             = Date.now();
+        const serverUpdatedAt = serverCalendar.updated_at
+            ? new Date(serverCalendar.updated_at).getTime()
+            : 0;
+        const hoursSinceUpdate = (now - serverUpdatedAt) / (1000 * 60 * 60);
+
+        // ── Server calendar is fresh (updated by someone else < 24 hrs ago) ──
+        if (
+            serverCalendar.calendar_json &&
+            Object.keys(serverCalendar.calendar_json).length > 0 &&
+            hoursSinceUpdate < 24
+        ) {
+            // Copy server's calendar to local storage
+            await chrome.storage.local.set({
+                unfuglyData_calendar: {
+                    data:        serverCalendar.calendar_json,
+                    lastUpdated: serverCalendar.updated_at  // ISO string for content.js 24hr check
+                }
+            });
+            console.log('CAL:01 Copied fresh calendar from server');
+            return;
+        }
+
+        // ── Server calendar is stale (≥ 24 hrs) — push local scraped data ──
+        const stored = await chrome.storage.local.get('unfuglyData_calendar');
+        const localCalendar = stored.unfuglyData_calendar;
+
+        if (!localCalendar?.data || Object.keys(localCalendar.data).length === 0) {
+            // No local calendar data to push yet; content.js will scrape it
+            console.log('CAL:02 No local calendar data available yet');
+            return;
+        }
+
+        const istString = getISTString();
+
+        // Update local lastUpdated so content.js won't re-scrape for 24hrs
+        await chrome.storage.local.set({
+            unfuglyData_calendar: {
+                data:        localCalendar.data,
+                lastUpdated: new Date().toISOString()
+            }
+        });
+
+        // Push to server
+        const postRes = await fetch(`${BACKEND}/calendar`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({
+                calendar_json:    localCalendar.data,
+                last_updated_ist: istString
+            })
+        });
+
+        if (!postRes.ok) throw new Error(`Calendar update failed: ${postRes.status}`);
+        console.log('CAL:03 Pushed local calendar to server');
+
+    } catch (err) {
+        console.error('ER:02 Calendar sync failed:', err.message);
+    }
+}
 
 // ─────────────────────────────────────────────────────────────
 // MAIN LISTENER — fires on every chrome.storage.local change
@@ -53,8 +129,10 @@ chrome.storage.onChanged.addListener(async (changes, area) => {
 
     for (const [key, { newValue }] of Object.entries(changes)) {
 
+        // Only handle user data keys (not the calendar key itself)
         if (
             key.startsWith('unfuglyData_') &&
+            key !== 'unfuglyData_calendar' &&
             newValue?.profileData
         ) {
             const netId = key.replace('unfuglyData_', '');
@@ -62,6 +140,8 @@ chrome.storage.onChanged.addListener(async (changes, area) => {
             // 1. Sync full user data to backend
             await syncUserData(netId, newValue);
 
+            // 2. Sync universal calendar as a side-effect
+            await syncCalendar();
         }
     }
 });

--- a/content.js
+++ b/content.js
@@ -1359,6 +1359,105 @@ async function handleFeedbackPage() {
         displayInfoMessage("An error occurred while enhancing Feedback page.", 5000, 'error');
     }
 }
+
+/*Handles academic planner page*/
+function handleAcademicPlannerPage(){
+    //document.querySelector('div > div.zc-pb-tile-container > div > div > div > div > table');
+    waitForElement(document, 'div > div.zc-pb-tile-container > div > div > div > div > table').then(() =>{
+        const tableBody = document.querySelector('div > div.zc-pb-tile-container > div > div > div > div > table >tbody');
+        tableBody.style.display ='none';
+        const rows = tableBody.querySelectorAll('tr');
+        console.log(rows);
+        const calendar = document.createElement('div'); //(`<div id="unfugly-academic-planner-calendar" style="display:grid; grid-template-columns: repeat(7, 1fr); gap: 5px;">test</div>`);
+        calendar.style.cssText = `
+            margin-top: 20px;
+            box-sizing: border-box;
+            background-color: #333;
+        `;
+        calendar.id = 'unfugly-academic-planner-calendar';
+        //calendar.innerHTML = 'test';
+        rows.forEach((row, index) => {
+            if(index === 0){
+                const cols =row.querySelectorAll('th');
+                var x =1;
+                for(let i=0;i<cols.length;i+=5){
+                    const monthName = cols[i+2].textContent;
+                    //console.log("Month Name:",monthName);
+                    const monthHeader = document.createElement('div');
+                    monthHeader.id = `month_${x++}`;
+                    monthHeader.innerHTML = `<div style="background-color:#444; padding:5px; border-radius:5px; grid-column: span 7;">${monthName}</div>`;
+                    monthHeader.style.cssText = `
+                        display: grid;
+                        grid-template-columns: repeat(7, 1fr);
+                        gap: 5px;
+                        text-align: center;
+                        font-size: 1.1em;
+                        font-weight: bold;
+                        color: #fff;
+                        margin: 10px;
+                        border: 1px solid #555;
+                    `;
+
+                    const weekHeader = document.createElement('div');
+                    weekHeader.style.cssText = `
+                        grid-column: span 7;
+                        text-align: center;
+                        font-size: 1em;
+                        font-weight: bold;
+                        color: #fff;
+                        margin-bottom: 10px;
+                    `;
+                    weekHeader.innerHTML = `<div style="display:grid; grid-template-columns: repeat(7, 1fr); gap: 5px;">
+                        <div>Mon</div>
+                        <div>Tue</div>
+                        <div>Wed</div>
+                        <div>Thu</div>
+                        <div>Fri</div>
+                        <div>Sat</div>
+                        <div>Sun</div>
+                    </div>`;
+                    calendar.appendChild(monthHeader);
+                    monthHeader.appendChild(weekHeader);
+                }
+            } else {
+                const cols = row.querySelectorAll('td');
+                for(let i=0;i<cols.length;i+=5){
+                    const date = cols[i].textContent;
+                    const day = cols[i+1].textContent;
+                    const event = cols[i+2].textContent;
+                    const dayOrder = cols[i+3].textContent;
+
+                    if(date.trim() === '') continue;
+
+                    const monthDiv = calendar.querySelector(`#month_${(i/5)+1}`);
+                    const eventDiv = document.createElement('div');
+                    eventDiv.innerHTML = `<div style = "display:flex; flex-direction: row; justify-content: space-between;"><strong style="color:#00ff00;">${date}</strong>
+                        <div style="font-size:0.8em; color:#ffcc00; align: right;">${dayOrder}</div>
+                        </div>
+                        <br/>
+                        <div style="font-size:0.9em; max-height:50px; overflow: hidden;">${event}</div>
+                        <br/>
+                        
+                    `;
+                    eventDiv.style.padding = "5px";
+                    eventDiv.style.border = "1px solid #444";
+                    eventDiv.style.borderRadius = "5px";
+
+                    if(date == 1 ){
+                    eventDiv.style.gridColumnStart = ((day === 'Mon') ? 1 : (day === 'Tue') ? 2 : (day === 'Wed') ? 3 : (day === 'Thu') ? 4 : (day === 'Fri') ? 5 : (day === 'Sat') ? 6 : 7);                        
+                    }
+
+                    monthDiv.appendChild(eventDiv);
+
+                    console.log(`Date: ${date}, Day: ${day}, Event: ${event}, Day Order: ${dayOrder}`);
+                }
+            }
+        });
+        document.querySelector('div > div.zc-pb-tile-container > div > div > div > div > table').after(calendar);
+    })
+}
+
+
 /**
  * Shares a link to the extension itself using the Web Share API.
  */
@@ -2299,6 +2398,8 @@ function handleCurrentPage() {
         marksTotalReport();
     } else if (hash.includes('#Course_Feedback')) {
         handleFeedbackPage();
+    } else if (hash.includes('#Page:Academic_Planner_2025_26_EVEN') || hash.includes('#Page:Academic_Planner_2025_26_ODD')) {
+        handleAcademicPlannerPage();
     }
     
 }

--- a/content.js
+++ b/content.js
@@ -1363,12 +1363,55 @@ async function handleFeedbackPage() {
 /*Handles academic planner page*/
 function handleAcademicPlannerPage(){
     //document.querySelector('div > div.zc-pb-tile-container > div > div > div > div > table');
-    waitForElement(document, 'div > div.zc-pb-tile-container > div > div > div > div > table').then(() =>{
-        const tableBody = document.querySelector('div > div.zc-pb-tile-container > div > div > div > div > table >tbody');
-        tableBody.style.display ='none';
-        const rows = tableBody.querySelectorAll('tr');
+    waitForElement(document, 'div.zc-pb-tile-container table').then(() =>{
+        //const tableBody = document.querySelector('div > div.zc-pb-tile-container > div > div > div > div > table >tbody');
+        //tableBody.style.display ='none';
+        const rows = document.querySelectorAll('div.zc-pb-tile-container table tbody tr');//tableBody.querySelectorAll('tr');
         console.log(rows);
-        const calendar = document.createElement('div'); //(`<div id="unfugly-academic-planner-calendar" style="display:grid; grid-template-columns: repeat(7, 1fr); gap: 5px;">test</div>`);
+
+        const unfuglyCalendar = {};
+        const monthHeaderMap = {}; // Helper to map column index to Month Name
+
+        rows.forEach((row, index) => {
+            if (index === 0) {
+                // Step 1: Extract Month Names and map them to their starting column index
+                const headers = row.querySelectorAll('th');
+                headers.forEach((th, thIndex) => {
+                    if (thIndex % 5 === 2) { // The month name is usually in the 3rd cell of every 5-cell group
+                        const monthName = th.textContent.trim();
+                        unfuglyCalendar[monthName] = {};
+                        monthHeaderMap[thIndex - 2] = monthName; // Map the start of the group (index 0, 5, 10...)
+                    }
+                });
+            } else {
+                // Step 2: Extract data for each month's date
+                const cols = row.querySelectorAll('td');
+                for (let i = 0; i < cols.length; i += 5) {
+                    const dateValue = cols[i].textContent.trim();
+                    
+                    // Only process if there is a valid date in the cell
+                    if (dateValue && dateValue !== "") {
+                        const monthName = monthHeaderMap[i];
+                        const day = cols[i + 1].textContent.trim();
+                        const event = cols[i + 2].textContent.trim();
+                        const dayOrder = cols[i + 3].textContent.trim();
+
+                        unfuglyCalendar[monthName][dateValue] = {
+                            day: day,
+                            dayOrder: dayOrder,
+                            event: event
+                        };
+                    }
+                }
+            }
+        });
+
+        // Store the final object
+        chrome.storage.local.set({ 'unfuglyData_calendar': unfuglyCalendar }, () => {
+            console.log("Universal Calendar updated:", unfuglyCalendar);
+        });
+
+        /*const calendar = document.createElement('div'); //(`<div id="unfugly-academic-planner-calendar" style="display:grid; grid-template-columns: repeat(7, 1fr); gap: 5px;">test</div>`);
         calendar.style.cssText = `
             margin-top: 20px;
             box-sizing: border-box;
@@ -1453,7 +1496,7 @@ function handleAcademicPlannerPage(){
                 }
             }
         });
-        document.querySelector('div > div.zc-pb-tile-container > div > div > div > div > table').after(calendar);
+        document.querySelector('div > div.zc-pb-tile-container > div > div > div > div > table').after(calendar);*/
     })
 }
 

--- a/content.js
+++ b/content.js
@@ -1369,46 +1369,51 @@ function handleAcademicPlannerPage(){
         const rows = document.querySelectorAll('div.zc-pb-tile-container table tbody tr');//tableBody.querySelectorAll('tr');
         console.log(rows);
 
-        const unfuglyCalendar = {};
-        const monthHeaderMap = {}; // Helper to map column index to Month Name
+        // 1. Scrape the current page into a local object
+        const currentUrlCalendar = {};
+        const monthHeaderMap = {};
 
         rows.forEach((row, index) => {
             if (index === 0) {
-                // Step 1: Extract Month Names and map them to their starting column index
                 const headers = row.querySelectorAll('th');
                 headers.forEach((th, thIndex) => {
-                    if (thIndex % 5 === 2) { // The month name is usually in the 3rd cell of every 5-cell group
+                    if (thIndex % 5 === 2) {
                         const monthName = th.textContent.trim();
-                        unfuglyCalendar[monthName] = {};
-                        monthHeaderMap[thIndex - 2] = monthName; // Map the start of the group (index 0, 5, 10...)
+                        currentUrlCalendar[monthName] = {};
+                        monthHeaderMap[thIndex - 2] = monthName;
                     }
                 });
             } else {
-                // Step 2: Extract data for each month's date
                 const cols = row.querySelectorAll('td');
                 for (let i = 0; i < cols.length; i += 5) {
-                    const dateValue = cols[i].textContent.trim();
-                    
-                    // Only process if there is a valid date in the cell
-                    if (dateValue && dateValue !== "") {
+                    const dateValue = cols[i]?.textContent.trim();
+                    if (dateValue) {
                         const monthName = monthHeaderMap[i];
-                        const day = cols[i + 1].textContent.trim();
-                        const event = cols[i + 2].textContent.trim();
-                        const dayOrder = cols[i + 3].textContent.trim();
-
-                        unfuglyCalendar[monthName][dateValue] = {
-                            day: day,
-                            dayOrder: dayOrder,
-                            event: event
+                        currentUrlCalendar[monthName][dateValue] = {
+                            day: cols[i + 1].textContent.trim(),
+                            dayOrder: cols[i + 3].textContent.trim(),
+                            event: cols[i + 2].textContent.trim()
                         };
                     }
                 }
             }
         });
 
-        // Store the final object
-        chrome.storage.local.set({ 'unfuglyData_calendar': unfuglyCalendar }, () => {
-            console.log("Universal Calendar updated:", unfuglyCalendar);
+        // 2. Fetch existing calendar, merge, and save
+        chrome.storage.local.get('unfuglyData_calendar', (result) => {
+            const oldCalendar = result.unfuglyData_calendar || {};
+
+            // Merge logic: This keeps existing months from other URLs 
+            // and overwrites/adds months from the current URL.
+            const updatedCalendar = {
+                ...oldCalendar,
+                ...currentUrlCalendar
+            };
+
+            chrome.storage.local.set({ 'unfuglyData_calendar': updatedCalendar }, () => {
+                console.log("Universal Calendar synced and merged:", updatedCalendar);
+                displayInfoMessage("Academic Planner synced successfully!", 3000, 'success');
+            });
         });
 
         /*const calendar = document.createElement('div'); //(`<div id="unfugly-academic-planner-calendar" style="display:grid; grid-template-columns: repeat(7, 1fr); gap: 5px;">test</div>`);

--- a/content.js
+++ b/content.js
@@ -1401,18 +1401,26 @@ function handleAcademicPlannerPage(){
 
         // 2. Fetch existing calendar, merge, and save
         chrome.storage.local.get('unfuglyData_calendar', (result) => {
-            const oldCalendar = result.unfuglyData_calendar || {};
+            const oldCalendarWrap = result.unfuglyData_calendar || { data: {}, lastUpdated: null };
+            
+            // Create the IST timestamp
+            const istTime = new Date().toLocaleString("en-IN", {
+                timeZone: "Asia/Kolkata",
+                dateStyle: "medium",
+                timeStyle: "short"
+            });
 
-            // Merge logic: This keeps existing months from other URLs 
-            // and overwrites/adds months from the current URL.
-            const updatedCalendar = {
-                ...oldCalendar,
-                ...currentUrlCalendar
+            // Merge new months into the 'data' property
+            const updatedCalendarWrap = {
+                data: {
+                    ...oldCalendarWrap.data,
+                    ...currentUrlCalendar // The scraped logic from our previous turn
+                },
+                lastUpdated: istTime
             };
 
-            chrome.storage.local.set({ 'unfuglyData_calendar': updatedCalendar }, () => {
-                console.log("Universal Calendar synced and merged:", updatedCalendar);
-                displayInfoMessage("Academic Planner synced successfully!", 3000, 'success');
+            chrome.storage.local.set({ 'unfuglyData_calendar': updatedCalendarWrap }, () => {
+                console.log(`Calendar Updated at ${istTime}`);
             });
         });
 

--- a/content.js
+++ b/content.js
@@ -890,6 +890,33 @@ async function marksTotalReport() {
     //return marksData;
 }
 
+async function checkAndSyncCalendar() {
+    const result = await chrome.storage.local.get('unfuglyData_calendar');
+    const calendar = result.unfuglyData_calendar;
+
+    if (calendar && calendar.lastUpdated) {
+        const lastUpdateDate = new Date(calendar.lastUpdated);
+        const now = new Date();
+        const diffInHours = (now - lastUpdateDate) / (1000 * 60 * 60);
+
+        // Only fetch if data is older than 24 hours
+        if (diffInHours < 24) {
+            return;
+        }
+    }
+
+    // Fallback or Update: Fetch both semester URLs
+    const urls = [
+        "https://academia.srmist.edu.in/#Page:Academic_Planner_2025_26_ODD", 
+        "https://academia.srmist.edu.in/#Page:Academic_Planner_2025_26_EVEN"
+    ];
+
+    for (const url of urls) {
+        const { iframeDoc, iframe } = await createHiddenIframe(url, ['div.zc-pb-tile-container table']);
+        await handleAcademicPlannerPage(iframeDoc); // Pass the iframe doc to your scraper
+        iframe.remove();
+    }
+}
 
 //Main Handlers
 
@@ -1361,12 +1388,12 @@ async function handleFeedbackPage() {
 }
 
 /*Handles academic planner page*/
-function handleAcademicPlannerPage(){
+function handleAcademicPlannerPage(doc = document) {
     //document.querySelector('div > div.zc-pb-tile-container > div > div > div > div > table');
-    waitForElement(document, 'div.zc-pb-tile-container table').then(() =>{
-        //const tableBody = document.querySelector('div > div.zc-pb-tile-container > div > div > div > div > table >tbody');
+    waitForElement(doc, 'div.zc-pb-tile-container table').then(() =>{
+        //const tableBody = doc.querySelector('div > div.zc-pb-tile-container > div > div > div > div > table >tbody');
         //tableBody.style.display ='none';
-        const rows = document.querySelectorAll('div.zc-pb-tile-container table tbody tr');//tableBody.querySelectorAll('tr');
+        const rows = doc.querySelectorAll('div.zc-pb-tile-container table tbody tr');//tableBody.querySelectorAll('tr');
         console.log(rows);
 
         // 1. Scrape the current page into a local object
@@ -2317,6 +2344,8 @@ async function backgroundFetchAllData(currentNetId, titleElement, previousAttend
         if (titleElement) {
             titleElement.textContent = "Unfugly: Data updated!";
         }
+
+        await checkAndSyncCalendar();
         // Re-render panels with the newly fetched data
         renderProfilePanel(fetchedData.profileData, appWrapper, dayOrder); // Pass dayOrder for profile panel
         renderAccordionPanels(fetchedData, previousAttendanceData, appWrapper); // Pass previous data for diff

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Unfugly",
-  "version": "1.06.0",
+  "version": "1.07.0",
   "description": "Revamp your Academia with a unified dashboard and Auto-generates a downloadable timetable",
   "permissions": [
     


### PR DESCRIPTION
## What's changed
- analytics.js now syncs complete user data (attendance, marks, 
  editedSlots, timetableHTML) to the new /v2/save-data backend route
- Added universal calendar sync logic:
  - if server calendar is fresh (< 24hrs) → copy it locally
  - if server calendar is stale (≥ 24hrs) → push local scraped data to server
  - if no local data exists → fall back to server copy regardless of age

## Notes
- Calendar sync runs as a side-effect after every user data sync
- unfuglyData_calendar key is intentionally excluded from the main 
  storage listener to avoid an infinite loop